### PR TITLE
Update dependency requirements for Magento 2.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "The Page Builder Source Code module adds a Source Code button to the toolbar of the Page Builder WYSIWYG editor.",
     "require": {
         "php": ">=7.1",
-        "magento/framework": "102.0.1.*",
-        "magento/module-page-builder": "1.0.0"
+        "magento/framework": "102.0.*",
+        "magento/module-page-builder": "1.0.*"
     },
     "type": "magento2-module",
     "version": "1.0.0",


### PR DESCRIPTION
In Magento 2.3.2:
- `magento/framework`: `102.0.1` => `102.0.2`
- `magento/module-page-builder`: `1.0.0` => `1.0.1`

This change allow the module to be installed in Magento 2.3.2.

Fix #1 