### PR TITLE
Re-add Magento Widget and Variable plugins

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -6,7 +6,8 @@
             <argument name="additionalSettings" xsi:type="array">
                 <item name="toolbar" xsi:type="string">
                     undo redo | styleselect | fontsizeselect | lineheightselect | forecolor backcolor | bold italic
-                    underline | alignleft aligncenter alignright | numlist bullist | link image table charmap | code
+                    underline | alignleft aligncenter alignright | numlist bullist | link image table charmap | code |
+                    magentowidget | magentovariable
                 </item>
             </argument>
         </arguments>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -5,9 +5,10 @@
         <arguments>
             <argument name="additionalSettings" xsi:type="array">
                 <item name="toolbar" xsi:type="string">
-                    undo redo | styleselect | fontsizeselect | lineheightselect | forecolor backcolor | bold italic
-                    underline | alignleft aligncenter alignright | numlist bullist | link image table charmap | code |
-                    magentowidget | magentovariable
+                    undo redo | styleselect | fontsizeselect | lineheightselect | forecolor backcolor
+                    | bold italic underline | alignleft aligncenter alignright | numlist bullist | link image table charmap
+                    | magentowidget | magentovariable
+                    | code
                 </item>
             </argument>
         </arguments>


### PR DESCRIPTION
Closes #8 

Saw this issue pop up somewhere on either LInkedIn or the Magento Slack and though I'd give it a crack. :sweat_smile: 

This was a slightly annoying issue to track down, but the main things to understand is that by passing an item to the `additionalSettings` array, this will completely override the values that are present in the default config provider in some JavaScript just prior to TinyMCE initialisation.

1. Default config provider declares configuration, which is then Magento'd into some javascript
2. This ends up [here](https://github.com/magento/magento2-page-builder/blob/v1.6.0/app/code/Magento/PageBuilder/view/adminhtml/web/js/wysiwyg/tinymce4.js#L78) and is initialized via pagebuilder
3. This then ends up [here](https://github.com/magento/magento2/blob/2.4.3-p1/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js#L81) in which the magento plugins are added to the toolbar (via this.config.tinymc4.toolbar)
4. Later in the same function, if `additionalSettings` exists, the settings are merged [here](https://github.com/magento/magento2/blob/2.4.3-p1/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js#L318-L320)
5. This then initialises TinyMCE with the merged settings [here](https://github.com/magento/magento2/blob/2.4.3-p1/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js#L118)

At step 3 the config would work. However, since step 4 merged the config from `additionalSettings` the toolbar value is then replace with the 'hardcoded' value we provide via the `di.xml` entry.

So we're left with 2 options:

1. Add `magentowidget` and `magentovariable` to the toolbar value in `di.xml`
	* This does mean this value will trump any plugins that may exist, and will require overriding in a module that is loaded after this one to change the toolbar configuration
2. Write an after plugin on `Magento\PageBuilder\Model\Wysiwyg\DefaultConfigProvider::getConfig` to add `code` instead of passing it in via `additionalSettings`

I've opted for option 1 because that's the current implementation; and the module is simplistic in nature.

![image](https://user-images.githubusercontent.com/4225347/156249720-42483736-ae0c-435b-b820-1ae7e0b11e0f.png)
