### PR TITLE
Update composer.json to resolve dependency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "The Page Builder Source Code module adds a Source Code button to the toolbar of the Page Builder WYSIWYG editor.",
     "require": {
         "php": "^7||^8",
-        "magento/framework": " >=100",
+        "magento/framework": "^100|^101|^102|^103",
         "magento/module-page-builder": "^1||^2"
     },
     "type": "magento2-module",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "magento/module-page-builder": "^1||^2"
     },
     "type": "magento2-module",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": [
         "MIT"
     ],

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "The Page Builder Source Code module adds a Source Code button to the toolbar of the Page Builder WYSIWYG editor.",
     "require": {
         "php": "^7||^8",
-        "magento/framework": "^100",
+        "magento/framework": " >=100",
         "magento/module-page-builder": "^1||^2"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Resolves:
markshust/magento2-module-pagebuildersourcecode 2.0.0 requires magento/framework ^100 -> found magento/framework[100.0.2, ..., 100.2.0-rc20] but the package is fixed to 103.0.5-p11 (lock file version) by a partial update and that version does not match.